### PR TITLE
Change SSID of 5 GHz client network

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -20,7 +20,7 @@
 		mesh_mcast_rate = 12000,
 	},
 	wifi5 = {
-		ssid = 'Freifunk (5GHz)',
+		ssid = 'Freifunk',
 		channel = 44,
 		htmode = 'HT40+',
 		mesh_ssid = 'mesh.ffe',


### PR DESCRIPTION
The 2.4 and 5 GHz networks should have the same SSID as the clients' devices automatically choose the network with the better SNR then.
