### PR TITLE
Update site.conf, site.mk

### DIFF
--- a/modules
+++ b/modules
@@ -1,0 +1,5 @@
+GLUON_SITE_FEEDS='ffe'
+
+PACKAGES_FFE_REPO=https://github.com/CodeFetch/packages-1.git
+PACKAGES_FFE_BRANCH=master
+PACKAGES_FFE_COMMIT=c0b04d7cf20fe4cdfe91f23c30904da4e5d20366

--- a/patches/0001-openwrt-patch-iw.patch
+++ b/patches/0001-openwrt-patch-iw.patch
@@ -1,0 +1,41 @@
+From: Karsten Böddeker <freifunk@kb-light.de>
+Date: Sat, 23 Apr 2016 15:20:30 +0200
+Subject: [PATCH] openwrt: patch iw
+
+---
+ .../1001-iw-patch-200-reduce-size-patch.patch      | 23 ++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+ create mode 100644 patches/openwrt/1001-iw-patch-200-reduce-size-patch.patch
+
+diff --git a/patches/openwrt/1001-iw-patch-200-reduce-size-patch.patch b/patches/openwrt/1001-iw-patch-200-reduce-size-patch.patch
+new file mode 100644
+index 0000000..09c978e
+--- /dev/null
++++ b/patches/openwrt/1001-iw-patch-200-reduce-size-patch.patch
+@@ -0,0 +1,23 @@
++From: Karsten Böddeker <freifunk@kb-light.de>
++Date: Sat, 23 Apr 2016 15:20:29 +0200
++Subject: iw: patch 200-reduce_size.patch
++
++diff --git a/package/network/utils/iw/patches/200-reduce_size.patch b/package/network/utils/iw/patches/200-reduce_size.patch
++index dea24fb..fefbf1f 100644
++--- a/package/network/utils/iw/patches/200-reduce_size.patch
+++++ b/package/network/utils/iw/patches/200-reduce_size.patch
++@@ -1,12 +1,11 @@
++ --- a/Makefile
++ +++ b/Makefile
++-@@ -15,8 +15,8 @@ CFLAGS += -Wall -Wundef -Wstrict-prototy
+++@@ -16,7 +16,7 @@ CFLAGS += -Wall -Wundef -Wstrict-prototy
++  OBJS = iw.o genl.o event.o info.o phy.o \
++  	interface.o ibss.o station.o survey.o util.o ocb.o \
++  	mesh.o mpath.o mpp.o scan.o reg.o version.o \
++--	reason.o status.o connect.o link.o offch.o ps.o cqm.o \
+++ 	reason.o status.o connect.o link.o offch.o ps.o cqm.o \
++ -	bitrate.o wowlan.o coalesce.o roc.o p2p.o vendor.o
++-+	reason.o status.o link.o offch.o ps.o cqm.o \
++ +	bitrate.o vendor.o
++  OBJS += sections.o
++  
+-- 
+2.1.4
+

--- a/site.conf
+++ b/site.conf
@@ -1,8 +1,7 @@
 {
-	hostname_prefix = 'FF-E',
+	hostname_prefix = '',
 	site_name = 'Freifunk Essen',
 	site_code = 'ffe',
-	
 	opkg = {
                 openwrt = 'http://openwrt.draic.info/%n/%v/%S/packages',
                 extra = {
@@ -16,9 +15,10 @@
 	timezone = 'CET-1CEST,M3.5.0,M10.5.0/3', -- Europe/Berlin
 	ntp_servers = {'1.ntp.services.ffe','2.ntp.services.ffe'},
 	regdom = 'DE',
-	
+
 	wifi24 = {
 		channel = 3,
+		htmode = 'HT40+',
 		ap = {
 			ssid = 'Freifunk',
 		},
@@ -30,6 +30,7 @@
 	},
 	wifi5 = {
 		channel = 44,
+		htmode = 'HT40+',
 		ap = {
 			ssid = 'Freifunk',
 		},
@@ -46,13 +47,18 @@
 		mac = '16:41:95:40:f7:dc',
 	},
 
+	mesh = {
+		batman_adv = {
+			gw_sel_class = 10,
+		},
+	},
+
 	fastd_mesh_vpn = {
 		methods = {'salsa2012+umac'},
 		configurable = true,
 		mtu = 1280,
 		groups = {
-			backbone = {limit = 0, peers = {},},
-			backbone_1 = {
+			backbone = {
 				limit = 1,
 				peers = {
 					node01 = {
@@ -62,19 +68,14 @@
 							'ipv6 "sn-a.ov.lil.freifunk-essen.net" port 10000'
 						},
 					},
-				},
-			},
-			backbone_2 = {
-				limit = 1,
-				peers = {
-					node01 = {
+					node02 = {
 						key = '6ed15e1d0d4774d4eccea568d6f8637f47749b82a3e7be336620c7ff89f1f9a7',
 						remotes = {
 							'ipv4 "sn-b.ov.lil.freifunk-essen.net" port 10000',
 							'ipv6 "sn-b.ov.lil.freifunk-essen.net" port 10000'
 						},
 					},
-					node02 = {
+					node03 = {
 						key = 'd65b0b6e2f52ec824bc5a5ef20f5841ef9d781999de178dcde35b43059e9d2e9',
 						remotes = {
 							'ipv4 "sn-a.ak.ber.freifunk-essen.net" port 10000',
@@ -83,6 +84,12 @@
 					},
 				},
 			},
+		},
+
+		bandwidth_limit = {
+			enabled = false,
+			egress = 4000,
+			ingress = 30000,
 		},
 	},
 
@@ -122,12 +129,10 @@
 		},
 	},
 
-	simple_tc = {
-		mesh_vpn = {
-			ifname = 'mesh-vpn',
-			enabled = false,
-			limit_egress = 4000,
-			limit_ingress = 30000,
+	config_mode = {
+		owner = {
+			obligatory = false
 		},
 	},
+
 }

--- a/site.mk
+++ b/site.mk
@@ -27,7 +27,20 @@ GLUON_SITE_PACKAGES := \
         iptables \
         haveged
 
-DEFAULT_GLUON_RELEASE := 0.8.3
+ifeq ($(GLUON_TARGET),x86-64)
+# support the usb stack on x86 devices
+# and add a few common USB NICs
+GLUON_SITE_PACKAGES += \
+	kmod-usb-core \
+	kmod-usb2 \
+	kmod-usb-hid \
+	kmod-usb-net \
+	kmod-usb-net-asix \
+	kmod-usb-net-dm9601-ether \
+	kmod-r8169
+endif
+
+DEFAULT_GLUON_RELEASE := 0.8.2
 
 # Allow overriding the release number from the command line
 GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)

--- a/site.mk
+++ b/site.mk
@@ -21,7 +21,7 @@ GLUON_SITE_PACKAGES := \
         gluon-mesh-vpn-fastd \
         gluon-radvd \
         gluon-respondd \
-	ffe-autoupdater-wifi-fallback\
+	ffe-autoupdater-wifi-fallback \
         gluon-setup-mode \
         gluon-status-page \
         iwinfo \

--- a/site.mk
+++ b/site.mk
@@ -21,11 +21,14 @@ GLUON_SITE_PACKAGES := \
         gluon-mesh-vpn-fastd \
         gluon-radvd \
         gluon-respondd \
+	ffe-autoupdater-wifi-fallback\
         gluon-setup-mode \
         gluon-status-page \
         iwinfo \
         iptables \
         haveged
+	
+	
 
 ifeq ($(GLUON_TARGET),x86-64)
 # support the usb stack on x86 devices


### PR DESCRIPTION
Updates site.conf for better gateway selection. Contact field isn't obligatory anymore.
HT40 behaviour was tested and is conform with German law. Thus corresponding site.conf parameters were reintroduced.
Adds modules for Futros in x64 builds in site.mk.
